### PR TITLE
fix(proxy): add Cloudflare Insights to CSP script-src

### DIFF
--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -38,8 +38,8 @@ server {
     add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
     add_header Cross-Origin-Resource-Policy "same-origin" always;
 
-    # CSP - Firebase + Google Auth + API mismo origen
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://www.gstatic.com https://firebase.googleapis.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; connect-src 'self' https://*.firebaseapp.com https://*.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; frame-src 'self' https://accounts.google.com https://*.firebaseapp.com; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self';" always;
+    # CSP - Firebase + Google Auth + Cloudflare Analytics + API mismo origen
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://accounts.google.com https://www.gstatic.com https://firebase.googleapis.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; connect-src 'self' https://*.firebaseapp.com https://*.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com; frame-src 'self' https://accounts.google.com https://*.firebaseapp.com; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self';" always;
 
     # Gzip compression
     gzip on;


### PR DESCRIPTION
Cloudflare Analytics (beacon.min.js) was blocked by CSP. Added 'https://static.cloudflareinsights.com' to script-src.